### PR TITLE
Revert "(#3) More versatile iterable implementation"

### DIFF
--- a/util/data_type_dict.py
+++ b/util/data_type_dict.py
@@ -4,16 +4,13 @@
 # data files, primarily used by mockimport.py
 #
 #######################################################
-import collections
 
-class MetaDict(type, collections.abc.Mapping):
+class MetaDict(type):
     def __iter__(self):
         for key in DataTypeDict.conversions:
             yield key
     def __getitem__(self, key):
         return DataTypeDict.getIdentFromVar(key)
-    def __len__(self):
-        return len(DataTypeDict.conversions)
 
 class DataTypeDict(metaclass=MetaDict):
     """Thie class is a simple mapping of variable names in glodap, to bodc


### PR DESCRIPTION
Turns out this change caused some unforseen problems. As it
is not strictly neccessary, I'm simply reverting it.
This reverts commit a7291e339fa4470d70df01833c29478f54c14a25.