### PR TITLE
(#6) Adding consistent sampl.  depth column

### DIFF
--- a/util/excread.py
+++ b/util/excread.py
@@ -68,6 +68,7 @@ def _excread(excfile):
     sampl_depth_columns = [
         'CTDDEPTH',
         'CTDDEP',
+	'CTDPRS',
     ]
 
     # Loop over the header to collect metadata and remove file type info

--- a/util/excread.py
+++ b/util/excread.py
@@ -64,6 +64,10 @@ def _excread(excfile):
     line = None
     headerlines = 0
     comments = ""
+    sampl_depth_columns = [
+        'CTDDEPTH',
+        'CTDDEP',
+    ]
 
     # Loop over the header to collect metadata and remove file type info
     while True:
@@ -146,6 +150,12 @@ def _excread(excfile):
                 )
                 raise e
         dataframe['EXC_DATETIME'] = datetime
+
+    # Try multiple sampling depth columns
+    for name in sampl_depth_columns:
+        if name in dataframe.columns:
+            dataframe['EXC_CTDDEPTH'] = dataframe[name]
+            break
 
     # Replace -9999, -999, -99, -9 with np.nan
     dataframe = dataframe.replace([-9999, -999, -99, -9], np.nan)

--- a/util/excread.py
+++ b/util/excread.py
@@ -24,6 +24,7 @@ def excread(path):
     Returns a pandas data frame object with the content parsed from the exc file.
     A column called EXC_DATETIME is added, holding actual date-time values for
     the file. If no times are found, time is set to 00:00
+    A column EXC_CTDDEPTH is added holding sampling depth (from CTDDEP or CTDDEP)
     """
 
     logger = logging.getLogger('glodap.util.excread')


### PR DESCRIPTION
To test: 
* start python prompt
```
>>> from glodap.util.excread import excread
>>> data = excread('/path/to/exchange-file')
>>> data['EXC_CTDDEPTH']
```
should output data from the sampling depth column. Currently, the data file needs either a CTDDEP or CTDDEPTH column defined, but more flexibility can be added to the excread-function when required.

close #6 