### PR TITLE
(#64) Remove date/time parse warnings during file import

### DIFF
--- a/util/excread.py
+++ b/util/excread.py
@@ -133,14 +133,13 @@ def _excread(excfile):
 
     # Add a datetime column. If time is not present, time is set to 00:00
     if 'DATE' in dataframe.columns and 'TIME' in dataframe.columns:
-        datetime = []
+        datetime = None
         for ix, d in enumerate(dataframe['DATE']):
             try:
                 t = dataframe['TIME'][ix]
                 date='{}-{}-{}'.format(d[:4], d[4:6], d[6:])
                 time = '{}:{}'.format(t[:2], t[2:])
-                datetime.append('{} {}'.format(date, time))
-                pd.to_datetime(datetime)
+                datetime = pd.to_datetime('{} {}'.format(date, time), utc=True)
             except Exception as e:
                 logger.error(
                     'Timer format error (date: {}) (time: {}) on line {}'

--- a/util/excread.py
+++ b/util/excread.py
@@ -133,13 +133,13 @@ def _excread(excfile):
 
     # Add a datetime column. If time is not present, time is set to 00:00
     if 'DATE' in dataframe.columns and 'TIME' in dataframe.columns:
-        datetime = None
+        datetime = []
         for ix, d in enumerate(dataframe['DATE']):
             try:
                 t = dataframe['TIME'][ix]
                 date='{}-{}-{}'.format(d[:4], d[4:6], d[6:])
                 time = '{}:{}'.format(t[:2], t[2:])
-                datetime = pd.to_datetime('{} {}'.format(date, time), utc=True)
+                datetime.append(pd.to_datetime('{} {}'.format(date, time), utc=True))
             except Exception as e:
                 logger.error(
                     'Timer format error (date: {}) (time: {}) on line {}'


### PR DESCRIPTION
Makes `EXC_DATETIME` a proper `datetime` object in `excread.py`, which is then parsed properly later on.

Close https://github.com/jonasfh/xover/issues/64

I'm not sure what the procedure is for updating the link to the correct commit from the xover repository. Do we update it once this is merged into the master branch?

**EDIT** I made a PR in xover to point lib/glodap to the commit here. Maybe that's the way to do it?